### PR TITLE
padRight test case

### DIFF
--- a/spec/string.test.ts
+++ b/spec/string.test.ts
@@ -9,4 +9,14 @@ describe('string', () => {
       expect(string.padLeft('123', 8, '0')).toEqual('00000123');
     });
   });
+
+  describe('padRight', () => {
+    it('文字-右邊填0', () => {
+      expect(string.padRight('demo', 8, '0')).toEqual('demo0000');
+    });
+
+    it('數字', () => {
+      expect(string.padRight('123', 8, '0')).toEqual('12300000');
+    });
+  });
 });


### PR DESCRIPTION
string should include `padLeft` and `padRight` at same time